### PR TITLE
Disable sorting in newslist. 

### DIFF
--- a/ringo_news/newslist.mako
+++ b/ringo_news/newslist.mako
@@ -38,7 +38,7 @@ var newslist = $('#newslisting').dataTable( {
        "bPaginate": false,
        "bLengthChange": false,
        "bFilter": false,
-       "bSort": true,
+       "bSort": false,
        /* Disable initial sort */
        "aaSorting": [],
        "bInfo": false,


### PR DESCRIPTION
Because of the current layout of the table sorting isn't possible in a correct way anyway
